### PR TITLE
Extend support for literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,17 @@ And your output will have the `convertTimestamps` declaration only if one of the
 
 This helps cut down on unnecessary output in the code, and compiler/IDE warnings like unused functions.
 
+# Literals
+
+If you want to add a literal value, you can use `literalOf` and `arrayOf`:
+
+| code                              | output                    |
+| --------------------------------- | ------------------------- |
+| `let a = ${literalOf('foo')}`     | `let a = 'foo';`          |
+| `let a = ${arrayOf(1, 2, 3)}`     | `let a = [1, 2, 3];`      |
+| `let a = ${{foo: 'bar'}}`         | `let a = { foo: 'bar' };` |
+| `` let a = ${{foo: code`bar`}} `` | `let a = { foo: bar };`   |
+
 History
 =======
 

--- a/src/Literal.ts
+++ b/src/Literal.ts
@@ -1,0 +1,61 @@
+import { Node } from './Node';
+import { MaybeOutput } from './ConditionalOutput';
+import { isPlainObject } from './is-plain-object';
+
+type Token = string | Node | MaybeOutput;
+
+/**
+ * A literal source representation of the provided object
+ */
+export class Literal extends Node {
+  private readonly tokens: Token[];
+
+  constructor(object: unknown) {
+    super();
+    this.tokens = flatten(object);
+  }
+
+  get childNodes(): unknown[] {
+    return this.tokens;
+  }
+
+  toCodeString(): string {
+    return this.tokens
+      .map((node) => {
+        if (typeof node === 'string') return node;
+        if (node instanceof Node) return node.toCodeString();
+        return '';
+      })
+      .join(' ');
+  }
+}
+
+function flatten(o: unknown): Token[] {
+  if (typeof o === 'undefined') {
+    return ['undefined'];
+  }
+  if (typeof o === 'object' && o != null) {
+    if (o instanceof Node || o instanceof MaybeOutput) {
+      return [o];
+    } else if (Array.isArray(o)) {
+      const nodes: Token[] = ['['];
+      for (let i = 0; i < o.length; i++) {
+        if (i !== 0) nodes.push(',');
+        nodes.push(...flatten(o[i]));
+      }
+      nodes.push(']');
+      return nodes;
+    } else if (isPlainObject(o)) {
+      const nodes: Token[] = ['{'];
+      const entries = Object.entries(o);
+      for (let i = 0; i < entries.length; i++) {
+        if (i !== 0) nodes.push(',');
+        const [key, value] = entries[i];
+        nodes.push(JSON.stringify(key), ':', ...flatten(value));
+      }
+      nodes.push('}');
+      return nodes;
+    }
+  }
+  return [JSON.stringify(o)];
+}

--- a/src/index-tests.tsx
+++ b/src/index-tests.tsx
@@ -384,28 +384,15 @@ describe('code', () => {
     const map = {
       foo: code`1`,
       bar: code`2 as ${imp('Foo@foo')}`,
+      'z-z': 'zaz',
+      zaz: { foo: code`3 as ${imp('Zaz@foo')}` },
     };
     const b = code`const map = ${map};`;
     expect(await b.toStringWithImports()).toMatchInlineSnapshot(`
-      "import { Foo } from 'foo';
+      "import { Foo, Zaz } from 'foo';
 
-      const map = { foo: 1, bar: 2 as Foo };
+      const map = { foo: 1, bar: 2 as Foo, 'z-z': 'zaz', zaz: { foo: 3 as Zaz } };
       "
-    `);
-  });
-
-  it('can make literal objects', async () => {
-    const map = literalOf({
-      foo: code`1`,
-      bar: code`2 as ${imp('Foo@foo')}`,
-      'z-z': 'zaz',
-      zaz: { foo: code`3 as ${imp('Zaz@foo')}` },
-    });
-    const b = code`const map = ${map};`;
-    expect(await b.toStringWithImports()).toMatchInlineSnapshot(`
-      "import { Foo } from 'foo';
-
-      const map = {foo :1,bar :2 as Foo,z-z :zaz,zaz :{\\"foo\\":{\\"literals\\":[\\"3 as \\",\\"\\"],\\"placeholders\\":[{\\"symbol\\":\\"Zaz\\",\\"source\\":\\"foo\\",\\"typeImport\\":false}],\\"trim\\":false,\\"oneline\\":false}},};"
     `);
   });
 
@@ -417,37 +404,20 @@ describe('code', () => {
       ${helperMethod.ifUsed}
     `;
     expect(await o.toStringWithImports()).toMatchInlineSnapshot(`
-      "module.exports = {
-        something: {
-          method: {
-            literals: ['', '()'],
-            placeholders: [
-              {
-                usageSiteName: 'foo',
-                declarationSiteCode: {
-                  literals: ['function foo() { return 1; }'],
-                  placeholders: [],
-                  trim: false,
-                  oneline: false,
-                },
-              },
-            ],
-            trim: false,
-            oneline: false,
-          },
-        },
-      };
+      "module.exports = { something: { method: foo() } };
+
+      function foo() {
+        return 1;
+      }
       "
     `);
   });
 
   it('can make literal strings', async () => {
-    const b = code`const str = ${literalOf('\n\r\v\t\b\f\u0000\xea\'"' as any)};`;
+    const b = code`const str = ${literalOf('\n\r\v\t\b\f\u0000\xea\'"')};`;
     expect(await b.toStringWithImports()).toMatchInlineSnapshot(`
+      "const str = '\\\\n\\\\r\\\\u000b\\\\t\\\\b\\\\f\\\\u0000ê\\\\'\\"';
       "
-      const str = {0 :
-      ,1 :
-      ,2 :,3 :	,4 :,5 :,6 : ,7 :ê,8 :',9 :\\",};"
     `);
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 import { Import } from './Import';
-import { Code, deepGenerate, Def } from './Code';
+import { Code, Def } from './Code';
 import { Node } from './Node';
 import { ConditionalOutput } from './ConditionalOutput';
 import { isPlainObject } from './is-plain-object';
+import { Literal } from './Literal';
 export { Code } from './Code';
 export { Import } from './Import';
 
@@ -20,33 +21,12 @@ export function code(literals: TemplateStringsArray, ...placeholders: unknown[])
   );
 }
 
-export function literalOf(object: object): Node {
-  return new (class extends Node {
-    get childNodes(): unknown[] {
-      return Object.values(object).flat();
-    }
-
-    toCodeString(): string {
-      let code = '{';
-      Object.entries(object).forEach(([key, value]) => {
-        code += `${key} :${deepGenerate(value)},`;
-      });
-      code += '}';
-      return code;
-    }
-  })();
+export function literalOf(object: unknown): Node {
+  return new Literal(object);
 }
 
 export function arrayOf(...elements: unknown[]): Node {
-  return new (class extends Node {
-    get childNodes(): unknown[] {
-      return elements;
-    }
-
-    toCodeString(): string {
-      return '[' + elements.map(deepGenerate).join(', ') + ']';
-    }
-  })();
+  return literalOf(elements);
 }
 
 export function joinCode(chunks: Code[], opts: { on?: string; trim?: boolean } = {}): Code {


### PR DESCRIPTION
I wanted to add a string and thought it wasn't obvious on how to do it. Only while implementing this I found that I could have just used `JSON.stringify`, but I think `literalOf` should just support strings as well (and basically everything else).

This PR doesn't touch `deepGenerate`, which means that `` code`const a = ${map}` `` will work correctly but `` code`const a = ${[map]}` `` doesn't. The issue is that at the point `deepGenerate` is executed, all the aliasing has already happened so it's too late to construct a Literal. Fixing this would require quite a lot of refactoring.

Another difference is that `Literal` will create the literal at construction time, while `deepGenerate` only generates code at the end:

```ts
const a = { foo: 'bar'};
const b = code`
  const a = ${[literalOf(a)]};
  const b = ${[a]};
`;
a.foo = 'qux';
console.log(b.toString())
```
```
const a = { foo: "bar" };
const b = { foo: "qux" };
```

An an actual issue: if you put a `MaybeOutput` inside a `Literal` it will never show up.