### PR TITLE
fix: maybeRelativePath: use posix separator

### DIFF
--- a/src/Import.ts
+++ b/src/Import.ts
@@ -377,7 +377,7 @@ export function maybeRelativePath(outputPath: string, importPath: string): strin
   importPath = path.normalize(importPath);
   outputPath = path.normalize(outputPath);
   const outputPathDir = path.dirname(outputPath);
-  let relativePath = path.relative(outputPathDir, importPath);
+  let relativePath = path.relative(outputPathDir, importPath).split(path.sep).join(path.posix.sep);
   if (!relativePath.startsWith('.')) {
     // ensure the js compiler recognizes this is a relative path.
     relativePath = './' + relativePath;


### PR DESCRIPTION
Hey there!

Because of the changes [made here](https://github.com/stephenh/ts-poet/pull/31/files). Imports working incorrect.

It will affect https://github.com/stephenh/ts-proto. So please fix it. It's already affecting us.

Here is explanation.

```proto
import "google/protobuf/timestamp.proto";
...
```

on Windows resulting path:
```typescript
import { Timestamp } from '..googleprotobuf\timestamp'; 
```

should be:
```typescript
import { Timestamp } from '../google/protobuf/timestamp';
```

Here is the fix of issue mentioned here

https://github.com/stephenh/ts-poet/issues/32