### PR TITLE
fix: imports to .js and .ts are resolved to the same file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /node_modules/
 *.DS_Store
 /build/
+/.log/

--- a/.npmignore
+++ b/.npmignore
@@ -11,4 +11,6 @@ build/docs
 **/*-tests.*
 coverage
 .nyc_output
+.circleci
+.idea
 *.log

--- a/src/Import.ts
+++ b/src/Import.ts
@@ -387,5 +387,8 @@ export function maybeRelativePath(outputPath: string, importPath: string): strin
 
 /** Checks if `path1 === path2` despite minor path differences like `./foo` and `foo`. */
 export function sameModule(path1: string, path2: string): boolean {
-  return path1 === path2 || path.resolve(path1) === path.resolve(path2);
+  // TypeScript: import paths ending in .js and .ts are resolved to the .ts file.
+  // Check the base paths (without the .js or .ts suffix).
+  const [basePath1, basePath2] = [path1, path2].map((p) => p.replace(/\.[tj]sx?/, ''));
+  return basePath1 === basePath2 || path.resolve(basePath1) === path.resolve(basePath2);
 }


### PR DESCRIPTION
The TypeScript compiler will recognize that an import to foo.js is actually an
import to foo.ts, if the .ts file exists and the .js file does not.

If two import paths are the same, ignoring a ".js" or ".ts" or ".jsx" suffix,
treat them as belonging to the same module.

---

Related to: https://github.com/stephenh/ts-proto/pull/602

We generate a file named foo.ts but import it as foo.js. The "path" passed as the "current module path" is "foo.ts" while the actual path used in the imports is "foo.js". This causes ts-poet to emit imports to the same file, i.e.:

Inside foo.ts: import { Foo } from './foo.js'

This PR fixes this by updating `sameModule` to drop the `.ts` or `.js` suffix when comparing paths.