### PR TITLE
Format source with prettier and ignore *.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.DS_Store
 /build/
 /.log/
+*.log

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "prepare": "yarn build && yarn test",
     "test": "yarn jest",
     "build": "yarn tsc",
-    "lint": "yarn tslint --project ."
+    "lint": "yarn tslint --project .",
+    "format": "prettier --write './src/**/(*.ts|*.tsx|*.html|*.css)'"
   },
   "repository": {
     "type": "git",

--- a/src/Code.ts
+++ b/src/Code.ts
@@ -42,7 +42,14 @@ export class Code extends Node {
    * to return a `Promise<String>`.
    */
   toStringWithImports(opts?: ToStringOpts): Promise<string> {
-    const { path = '', forceDefaultImport, forceModuleImport, prefix, prettierOverrides = {}, importMappings = {} } = opts || {};
+    const {
+      path = '',
+      forceDefaultImport,
+      forceModuleImport,
+      prefix,
+      prettierOverrides = {},
+      importMappings = {},
+    } = opts || {};
     const ourModulePath = path.replace(/\.[tj]sx?/, '');
     if (forceDefaultImport || forceModuleImport) {
       this.deepReplaceNamedImports(forceDefaultImport || [], forceModuleImport || []);

--- a/src/Import-tests.ts
+++ b/src/Import-tests.ts
@@ -153,7 +153,7 @@ describe('Import', () => {
     expect(sym.symbol).toEqual('Empty');
     expect(sym.source).toEqual('./google/protobuf/empty');
 
-    const importMappings = { './google/protobuf/empty': './external/protoapis/google/protobuf/empty' }
+    const importMappings = { './google/protobuf/empty': './external/protoapis/google/protobuf/empty' };
     expect(emit(sym, importMappings)).toMatchInlineSnapshot(
       `"import { Empty } from './external/protoapis/google/protobuf/empty';"`
     );

--- a/src/Import.ts
+++ b/src/Import.ts
@@ -286,7 +286,11 @@ export class SideEffect extends Imported {
 }
 
 /** Generates the `import ...` lines for the given `imports`. */
-export function emitImports(imports: Import[], ourModulePath: string, importMappings: { [key: string]: string }): string {
+export function emitImports(
+  imports: Import[],
+  ourModulePath: string,
+  importMappings: { [key: string]: string }
+): string {
   if (imports.length == 0) {
     return '';
   }
@@ -363,7 +367,7 @@ export function emitImports(imports: Import[], ourModulePath: string, importMapp
 type Constructor<T> = new (...args: any[]) => T;
 
 function filterInstances<T, U>(list: T[], t: Constructor<U>): U[] {
-  return (list.filter((e) => e instanceof t) as unknown) as U[];
+  return list.filter((e) => e instanceof t) as unknown as U[];
 }
 
 function unique<T>(list: T[]): T[] {


### PR DESCRIPTION
Minor housekeeping: format files with Prettier (add yarn format command) and remove *.log files as well (in .gitignore).