### PR TITLE
Improve arrays performance

### DIFF
--- a/src/Code.ts
+++ b/src/Code.ts
@@ -67,9 +67,10 @@ export class Code extends Node {
     const imports: Import[] = [];
     const defs: Def[] = [];
     const todo: unknown[] = [this];
+    let i = 0;
 
-    while (todo.length > 0) {
-      const placeholder = todo.shift();
+    while (i < todo.length) {
+      const placeholder = todo[i++];
 
       if (placeholder instanceof Node) {
         todo.push(...placeholder.childNodes);
@@ -107,18 +108,20 @@ export class Code extends Node {
     }
 
     const todo: unknown[] = [this];
-    while (todo.length > 0) {
-      const placeholder = todo.shift();
+    let i = 0;
+
+    while (i < todo.length) {
+      const placeholder = todo[i++];
       if (placeholder instanceof Node) {
         const array = placeholder.childNodes;
-        for (let i = 0; i < array.length; i++) {
-          const maybeImp = array[i]!;
+        for (let j = 0; j < array.length; j++) {
+          const maybeImp = array[j]!;
           if (maybeImp instanceof ImportsName && forceDefaultImport.includes(maybeImp.source)) {
             const name = getName(maybeImp.source);
-            array[i] = code`${new ImportsDefault(name, maybeImp.source)}.${maybeImp.sourceSymbol || maybeImp.symbol}`;
+            array[j] = code`${new ImportsDefault(name, maybeImp.source)}.${maybeImp.sourceSymbol || maybeImp.symbol}`;
           } else if (maybeImp instanceof ImportsName && forceModuleImport.includes(maybeImp.source)) {
             const name = getName(maybeImp.source);
-            array[i] = code`${new ImportsAll(name, maybeImp.source)}.${maybeImp.sourceSymbol || maybeImp.symbol}`;
+            array[j] = code`${new ImportsAll(name, maybeImp.source)}.${maybeImp.sourceSymbol || maybeImp.symbol}`;
           }
         }
         todo.push(...placeholder.childNodes);
@@ -165,8 +168,9 @@ export class Code extends Node {
 export function deepGenerate(object: unknown): string {
   let result = "";
   let todo: unknown[] = [object];
-  while (todo.length > 0) {
-    const current = todo.shift();
+  let i = 0;
+  while (i < todo.length) {
+    const current = todo[i++];
     if (Array.isArray(current)) {
       todo.push(...current);
     } else if (current instanceof Node) {


### PR DESCRIPTION
Hi, it's me again!

I continued profiling and found that the performance issue is still with the same functions.

Methods that work with the head of an array (shift, unshift) are slow operations. So I changed them to work with cursor (index). This insignificantly affects the amount of memory consumed, since only references to objects are stored in the array.

The same benchmark as in my previous PR (https://github.com/stephenh/ts-poet/pull/38) showed the following results:
```
Old: 1000 lines x 2,763 ops/sec ±1.14% (92 runs sampled)
New: 1000 lines x 3,634 ops/sec ±0.53% (93 runs sampled)
Old: 2000 lines x 1,472 ops/sec ±0.80% (92 runs sampled)
New: 2000 lines x 1,977 ops/sec ±0.42% (95 runs sampled)
Old: 3000 lines x 1,004 ops/sec ±0.63% (94 runs sampled)
New: 3000 lines x 1,370 ops/sec ±0.22% (95 runs sampled)
Old: 4000 lines x 755 ops/sec ±0.90% (93 runs sampled)
New: 4000 lines x 1,023 ops/sec ±0.52% (95 runs sampled)
Old: 5000 lines x 560 ops/sec ±2.90% (92 runs sampled)
New: 5000 lines x 763 ops/sec ±0.46% (94 runs sampled)
Old: 6000 lines x 473 ops/sec ±0.95% (92 runs sampled)
New: 6000 lines x 640 ops/sec ±0.30% (90 runs sampled)
Old: 7000 lines x 403 ops/sec ±0.49% (92 runs sampled)
New: 7000 lines x 543 ops/sec ±0.86% (91 runs sampled)
Old: 8000 lines x 349 ops/sec ±0.96% (92 runs sampled)
New: 8000 lines x 477 ops/sec ±0.42% (93 runs sampled)
Old: 9000 lines x 309 ops/sec ±1.17% (88 runs sampled)
New: 9000 lines x 421 ops/sec ±0.47% (92 runs sampled)
Old: 10000 lines x 280 ops/sec ±0.38% (89 runs sampled)
New: 10000 lines x 373 ops/sec ±2.94% (91 runs sampled)
```

Not so impressive. But on my real input .proto is much better: 2s instead of 6s. This is close enough to how C++ plugins work.

Ts-poet tests are green. Ts-proto integration tests are also green.