### PR TITLE
Fix relative import handling in maybeRelativePath function

### DIFF
--- a/src/Import-tests.ts
+++ b/src/Import-tests.ts
@@ -110,6 +110,10 @@ describe("Import", () => {
     expect(maybeRelativePath("./zaz/Zaz", "./foo/Foo")).toEqual("../foo/Foo");
   });
 
+  it("can handle relative imports where importing file is in a folder with the same name as file it is importing in a folder above it", () => {
+    expect(maybeRelativePath("./foo/bar", "./foo")).toEqual("../foo");
+  });
+
   it("import an export with a more convenient alias", () => {
     const parsed = Import.from("Observable:CustomizedObservable@packages/override-properties/Observable");
     expect(parsed).toBeInstanceOf(ImportsName);

--- a/src/Import.ts
+++ b/src/Import.ts
@@ -346,10 +346,6 @@ export function maybeRelativePath(outputPath: string, importPath: string): strin
     // importing a file that is named the same thing as the directory the file doing the importing is in.
     // e.g. importing `./foo` from `./foo/index.ts`
     // the import statement should read `../foo` not `./`
-
-    // if path is a directory, we need to pop off the last directory.
-
-    // otherwise, we need to prepend "../" to the path.
     return ".." + path.sep + path.basename(importPath);
   }
   let relativePath = path.relative(outputPathDir, importPath).split(path.sep).join(path.posix.sep);

--- a/src/Import.ts
+++ b/src/Import.ts
@@ -342,6 +342,16 @@ export function maybeRelativePath(outputPath: string, importPath: string): strin
   importPath = path.normalize(importPath);
   outputPath = path.normalize(outputPath);
   const outputPathDir = path.dirname(outputPath);
+  if (outputPathDir === importPath) {
+    // importing a file that is named the same thing as the directory the file doing the importing is in.
+    // e.g. importing `./foo` from `./foo/index.ts`
+    // the import statement should read `../foo` not `./`
+
+    // if path is a directory, we need to pop off the last directory.
+
+    // otherwise, we need to prepend "../" to the path.
+    return ".." + path.sep + path.basename(importPath);
+  }
   let relativePath = path.relative(outputPathDir, importPath).split(path.sep).join(path.posix.sep);
   if (!relativePath.startsWith(".")) {
     // ensure the js compiler recognizes this is a relative path.

--- a/src/standalone-tests.ts
+++ b/src/standalone-tests.ts
@@ -1,4 +1,4 @@
-import { code } from "./index";
+import { code, imp } from "./index";
 
 // When loaded from a CDN, most of them will use the standalone version of prettier because it has
 // `"browser": "./standalone.js"` (and also "unpkg") in it's package.json. These tests verify basic functionality in
@@ -24,5 +24,13 @@ describe("standalone", () => {
       "const a = <div class="test">Test</div>;
       "
     `);
+  });
+
+  it("test", async () => {
+    let b = code`${imp("Simple@./ui")}`;
+    expect(b.toString({ path: "ui/simple.ts" })).toContain('"../ui"');
+
+    b = code`${imp("Simpleton@./another/path/to/ui")}`;
+    expect(b.toString({ path: "another/path/to/ui/simple.ts" })).toContain('"../ui"');
   });
 });


### PR DESCRIPTION
This PR primarily focuses on improving the handling of relative imports in the `src/Import.ts`. It adds a condition to handle cases where the importing file is in a directory with the same name as the file it is importing from a directory above it.

```js
// --- BEFORE
// file doing the importing: ./foo/bar
// file being imported: ./foo
// resulting import statement: ./

// --- AFTER
// file doing the importing: ./foo/bar
// file being imported: ./foo
// resulting import statement: ../foo
```

It also includes minor changes to the `src/standalone-tests.ts` and `src/Import-tests.ts` files to test the import functionality. 