### PR TITLE
fix: pass string opts to non-overwrite path

### DIFF
--- a/src/saveFiles.ts
+++ b/src/saveFiles.ts
@@ -69,7 +69,7 @@ export async function saveFiles(opts: SaveFilesOpts): Promise<void> {
           await fs.writeFile(path, prefix + String(initialLength + lengthLength + pad) + suffix);
         }
       } else if (!exists) {
-        await fs.writeFile(path, contentToString(file, {}));
+        await fs.writeFile(path, contentToString(file, toStringOpts));
       }
     }),
   );


### PR DESCRIPTION
As discovered in https://github.com/joist-orm/joist-orm/pull/1025, the non-overwrite path did not pass in any `toStringOpts`. I had a gander through and _think_ this is correct to pass them all in - if not we could change this to just pass in importExtentions.