### PR TITLE
Remove regex pattern restrictions from the module specifier.

### DIFF
--- a/src/Import-tests.ts
+++ b/src/Import-tests.ts
@@ -139,6 +139,68 @@ describe("Import", () => {
     );
   });
 
+  it("can handle module spec with square brackets", () => {
+    const parsed = Import.from("handler@./route/[name]/index");
+    expect(parsed).toBeInstanceOf(ImportsName);
+
+    const sym = parsed as ImportsName;
+    expect(sym.symbol).toEqual("handler");
+    expect(sym.source).toEqual("./route/[name]/index");
+    expect(emit(sym)).toMatchInlineSnapshot(`"import { handler } from './route/[name]/index';"`);
+  });
+
+  it("can handle module spec with parenthesis", () => {
+    const parsed = Import.from("handler@./route/(group)/index");
+    expect(parsed).toBeInstanceOf(ImportsName);
+
+    const sym = parsed as ImportsName;
+    expect(sym.symbol).toEqual("handler");
+    expect(sym.source).toEqual("./route/(group)/index");
+    expect(emit(sym)).toMatchInlineSnapshot(`"import { handler } from './route/(group)/index';"`);
+  });
+
+  it("can handle module spec with unusual characters", () => {
+    const parsed = Import.from("handler@./route{/:name+}?/:path*");
+    expect(parsed).toBeInstanceOf(ImportsName);
+
+    const sym = parsed as ImportsName;
+    expect(sym.symbol).toEqual("handler");
+    expect(sym.source).toEqual("./route{/:name+}?/:path*");
+    expect(emit(sym)).toMatchInlineSnapshot(`"import { handler } from './route{/:name+}?/:path*';"`);
+  });
+
+  it("can handle a http URL module spec", () => {
+    const parsed = Import.from("something@http://example.com/something");
+    expect(parsed).toBeInstanceOf(ImportsName);
+
+    const sym = parsed as ImportsName;
+    expect(sym.symbol).toEqual("something");
+    expect(sym.source).toEqual("http://example.com/something");
+    expect(emit(sym)).toMatchInlineSnapshot(`"import { something } from 'http://example.com/something';"`);
+  });
+
+  it("can handle a node: module spec", () => {
+    const parsed = Import.from("URL@node:url");
+    expect(parsed).toBeInstanceOf(ImportsName);
+
+    const sym = parsed as ImportsName;
+    expect(sym.symbol).toEqual("URL");
+    expect(sym.source).toEqual("node:url");
+    expect(emit(sym)).toMatchInlineSnapshot(`"import { URL } from 'node:url';"`);
+  });
+
+  it("can handle a jsr: module spec", () => {
+    const parsed = Import.from("assertEquals@jsr:/@std/assert@^0.223.0/assert-equals");
+    expect(parsed).toBeInstanceOf(ImportsName);
+
+    const sym = parsed as ImportsName;
+    expect(sym.symbol).toEqual("assertEquals");
+    expect(sym.source).toEqual("jsr:/@std/assert@^0.223.0/assert-equals");
+    expect(emit(sym)).toMatchInlineSnapshot(
+      `"import { assertEquals } from 'jsr:/@std/assert@^0.223.0/assert-equals';"`,
+    );
+  });
+
   function emit(
     spec: Import,
     importMappings = {},

--- a/src/Import.ts
+++ b/src/Import.ts
@@ -3,8 +3,7 @@ import { Node } from "./Node";
 import { last, groupBy } from "./utils";
 
 const typeImportMarker = "(?:t:)?";
-const fileNamePattern = "(?:[a-zA-Z0-9._-]+)";
-const modulePattern = `@?(?:(?:${fileNamePattern}(?:/${fileNamePattern})*))`;
+const modulePattern = `.+`;
 const identPattern = `(?:(?:[a-zA-Z][_a-zA-Z0-9.]*)|(?:[_a-zA-Z][_a-zA-Z0-9.]+))`;
 export const importType = "[*@+=]";
 const importPattern = `^(${typeImportMarker}${identPattern})?(${importType})(${modulePattern})`;


### PR DESCRIPTION
I've completely removed `fileNamePattern` and replaced `modulePattern` with `.+` to allow use of any characters in the module specifier.

I've added a bunch of tests for common cases with unusual characters, along with URL, node: & jsr: style imports.

The ECMAScript spec imposes no restrictions on the module specifier string... https://tc39.es/ecma262/#prod-ModuleSpecifier.

Closes #58 