### PR TITLE
feat: Adding the ability to import helpers from another source

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,48 @@ And your output will have the `convertTimestamps` declaration only if one of the
 
 This helps cut down on unnecessary output in the code, and compiler/IDE warnings like unused functions.
 
+## utils file
+
+Sometimes the generated utilities are repeated in different files, and it makes sense to put them in a separate file.
+
+To do this, you can specify that all helpers are imported from a separate module:
+
+```ts
+const convertTimestamps = conditionalOutput(
+  "convertTimestamps",
+  code`function convertTimestamps(value: any) { ...impl... }`,
+);
+
+const output = code`
+  const timestamp = ${convertTimestamps}(...)
+`;
+
+const stringResult = output.toString({
+  conditionalUtils: './utils.ts'
+})
+```
+As a result, the code will be generated as if the helper had been imported.
+
+Generating the content itself for the `utils.ts` file will look something like this:
+
+```ts
+import { generateConditionalsUtils, code } from 'ts-poet'
+
+// get a list of all the helpers used in the code
+const utils = output.collectConditionalOutputs()
+
+// Create code that includes all helpers and their dependencies
+const utilsCode = generateConditionalsUtils(utils)
+
+const utilsCodeWithExport = code`
+${utilsCode}
+
+export {
+  ${utils.map(({ usageSiteName }) => usageSiteName).join(', ')}
+}
+`
+```
+
 # Literals
 
 If you want to add a literal value, you can use `literalOf` and `arrayOf`:

--- a/src/ConditionalOutput.ts
+++ b/src/ConditionalOutput.ts
@@ -13,6 +13,11 @@ import { Code } from "./Code";
  * to output the declaration conditionally only if `someHelper` has been
  * seen in the tree.
  *
+ * Additionally, if the `conditionalUtils` option is provided when calling 
+ * `toString()`, all `ConditionalOutput` instances will be imported from the specified file.
+ *
+ * The `isType` flag (optional) determines whether the helper should be imported as a TypeScript type when using `conditionalUtils`.
+ *
  * ```typescript
  * const someHelper = conditionalOutput(
  *   "someHelper",
@@ -38,6 +43,7 @@ export class ConditionalOutput extends Node {
   constructor(
     public usageSiteName: string,
     public declarationSiteCode: Code,
+    public isType: boolean = false
   ) {
     super();
   }

--- a/src/conditional-outputs-utils-tests.ts
+++ b/src/conditional-outputs-utils-tests.ts
@@ -1,0 +1,51 @@
+import { conditionalOutput, code, generateConditionalsUtils } from '../src'
+
+describe('conditional outputs in the utilities file', () => {
+    it('basic usage', () => {
+        const util = conditionalOutput(
+            'add',
+            code`const add(a: number, b: number) => a + b`
+        )
+
+        const codeChunk = code`const result = ${util}(1, 2)`
+
+        expect(codeChunk.toString({ conditionalUtils: './utils.ts' }))
+            .toBe('import { add } from "./utils.ts";\n\nconst result = add(1, 2);\n')
+    })
+
+    it('import type', () => {
+        const util = conditionalOutput('SomeId', code`type SomeId = string | number`, true)
+
+        const codeChunk = code`declare const id: ${util}`
+
+
+        expect(codeChunk.toString({ conditionalUtils: './utils.ts' }))
+            .toBe('import { type SomeId } from "./utils.ts";\n\ndeclare const id: SomeId;\n')
+    })
+
+    it('nested code generation', () => {
+        const someId = conditionalOutput('SomeId', code`type SomeId = string | number`, true)
+        const add = conditionalOutput('add', code`const add(a: number, b: number) => a + b`)
+
+        const childCode = code`declare const id: ${someId}`
+        const codeChunk = code`
+            ${childCode}
+            const result = ${add}(1, 2)
+        `
+
+        expect(codeChunk.toString({ conditionalUtils: './utils.ts' }))
+            .toBe('import { add, type SomeId } from "./utils.ts";\n\ndeclare const id: SomeId;\nconst result = add(1, 2);\n')
+    })
+
+    it('generate utils code', () => {
+        const someType = conditionalOutput('SomeType', code`type SomeType = number`)
+        const someId = conditionalOutput('SomeId', code`type SomeId = string | ${someType}`)
+
+        const codeChunk = code`declare const id: ${someId}`
+        const utils = codeChunk.collectConditionalOutputs()
+        const utilsCode = generateConditionalsUtils(utils)
+
+        expect(utilsCode.toString())
+            .toBe('type SomeType = number;\ntype SomeId = string | SomeType;\n')
+    })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,21 @@ export function def(symbol: string): Def {
 }
 
 /** Creates a conditionally-output code snippet. */
-export function conditionalOutput(usageSite: string, declarationSite: Code): ConditionalOutput {
-  return new ConditionalOutput(usageSite, declarationSite);
+export function conditionalOutput(usageSite: string, declarationSite: Code, isType?: boolean): ConditionalOutput {
+  return new ConditionalOutput(usageSite, declarationSite, isType);
+}
+
+/** Generates a `Code` block containing the provided `ConditionalOutput` declarations along with all their dependencies. */
+export function generateConditionalsUtils(used: ConditionalOutput[]): Code {
+  const mainChunk = joinCode([
+    ...used.map(({declarationSiteCode }) => declarationSiteCode)
+  ], {on: '\n', trim: false})
+
+  const uniqueOutputs = [...new Set(mainChunk.collectConditionalOutputs())]
+    .filter(output => !used.includes(output))
+
+  return joinCode([
+    ...uniqueOutputs.map(output => code`${output.ifUsed}`),
+    mainChunk,
+  ], {on: '\n'})
 }


### PR DESCRIPTION
In one of my projects, I have encountered a problem that generation creates unnecessarily large files. This slows down the build and makes it difficult for some utilities to analyze them. And more than half of each file is repetitive code (generated with `conditionalOutput`). I think the best solution is to put the repetitive code in a separate file.

The intended use case is described in the tests and `README.md`. The implementation does not break the current logic, but supplements it.

If this implementation is not suitable for some reason, I would appreciate a similar feature. Thanks.