### PR TITLE
feat: Add support for child symbols.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Given the primary goal of ts-poet is managing imports, there are several ways of
 * `imp("Observable@rxjs")` --> `import { Observable } from "rxjs"` (named import)
 * `imp("Observable@./Api")` --> `import { Observable } from "./Api"`
 * `imp("Observable:Obs@rxjs")` --> `import { Observable as Obs } from "rxjs"` (renamed import)
+* `imp("Knex.Transaction@knex")` --> `import { Knex } from "knex"` (named import)
 * `imp("t:Observable@rxjs")` --> `import type { Observable } from "rxjs"` (type import)
 * `imp("t:Observable:Obs@rxjs")` --> `import type { Observable as Obs } from "rxjs"`
 * `imp("api*./Api")` --> `import * as api from "./Api"` (namespace import)

--- a/src/index-tests.tsx
+++ b/src/index-tests.tsx
@@ -110,6 +110,19 @@ describe("code", () => {
     `);
   });
 
+  it("can use child symbols/namespaced types", () => {
+    const txn = imp("Knex.Transaction@knex");
+    const b = code`
+      const txn: ${txn} = null!;
+    `;
+    expect(b.toString()).toMatchInlineSnapshot(`
+      "import { Knex } from "knex";
+
+      const txn: Knex.Transaction = null!;
+      "
+    `);
+  });
+
   it("dedups imports", () => {
     const b = code`
       const a = ${imp("Bar@bar")};
@@ -711,4 +724,17 @@ describe("code", () => {
       "
     `);
   });
+  //
+  // it("can do parameter decorators", () => {
+  //   const params = [
+  //     code`@Param() param1: string`,
+  //     code`@Param() param2: number`,
+  //   ];
+  //   const a = code`
+  //     export interface Foo {
+  //       methodCall(${joinCode(params, { on: ", "})}): void;
+  //     }
+  //   `;
+  //   expect(a.toCodeString([])).toEqual("delicious taco");
+  // });
 });


### PR DESCRIPTION
I.e. importing:

```ts
const txn = imp("Knex.Transaction@knex");
```

And having it output like:

```ts
import { Knex } from "knex";

type TX = Knex.Transaction;
```